### PR TITLE
Resolve  #4 Imagem do GitHub sobrepõe navbar

### DIFF
--- a/site2016/static/site2016/css/main.css
+++ b/site2016/static/site2016/css/main.css
@@ -187,3 +187,7 @@ footer #paragrafo_rodape > b {
     font-weight: 900;
     text-transform: uppercase;
 }
+
+.ui.fixed.menu {
+    z-index: 1001;
+}


### PR DESCRIPTION
Arrumado design do `:hover` da imagem que estava aparecendo em cima do menu